### PR TITLE
Add Mouse Support

### DIFF
--- a/addons/GGS/logic/keybind_kb.gd
+++ b/addons/GGS/logic/keybind_kb.gd
@@ -8,7 +8,7 @@ extends Node
 func main(value: Dictionary) -> void:
 	var target_action: String = value["action_name"]
 	var action_list: Array = InputMap.get_action_list(target_action)
-	var prev_event: InputEventWithModifiers = Utils.array_find_type(action_list, "InputEventWithModifiers")
+	var prev_event: InputEventKey = Utils.array_find_type(action_list, "InputEventWithModifiers")
 	var new_event: InputEventWithModifiers
 	if value["value"] > 24:
 		new_event = InputEventKey.new()

--- a/addons/GGS/logic/keybind_kb.gd
+++ b/addons/GGS/logic/keybind_kb.gd
@@ -8,9 +8,14 @@ extends Node
 func main(value: Dictionary) -> void:
 	var target_action: String = value["action_name"]
 	var action_list: Array = InputMap.get_action_list(target_action)
-	var prev_event: InputEventKey = Utils.array_find_type(action_list, "InputEventKey")
-	var new_event: InputEventKey = InputEventKey.new()
-	new_event.scancode = value["value"]
+	var prev_event: InputEventWithModifiers = Utils.array_find_type(action_list, "InputEventWithModifiers")
+	var new_event: InputEventWithModifiers
+	if value["value"] > 24:
+		new_event = InputEventKey.new()
+		new_event.scancode = value["value"]
+	else:
+		new_event = InputEventMouseButton.new()
+		new_event.button_index = value["value"]
 
 	InputMap.action_erase_event(target_action, prev_event)
 	InputMap.action_add_event(target_action, new_event)

--- a/addons/GGS/logic/keybind_kb.gd
+++ b/addons/GGS/logic/keybind_kb.gd
@@ -8,7 +8,9 @@ extends Node
 func main(value: Dictionary) -> void:
 	var target_action: String = value["action_name"]
 	var action_list: Array = InputMap.get_action_list(target_action)
-	var prev_event: InputEventKey = Utils.array_find_type(action_list, "InputEventWithModifiers")
+	var prev_event: InputEventWithModifiers = Utils.array_find_type(action_list, "InputEventKey")
+	if prev_event == null:
+		prev_event = Utils.array_find_type(action_list, "InputEventMouseButton")
 	var new_event: InputEventWithModifiers
 	if value["value"] > 24:
 		new_event = InputEventKey.new()

--- a/addons/GGS/logic/keybind_kb.gd
+++ b/addons/GGS/logic/keybind_kb.gd
@@ -8,10 +8,15 @@ extends Node
 func main(value: Dictionary) -> void:
 	var target_action: String = value["action_name"]
 	var action_list: Array = InputMap.get_action_list(target_action)
+	
+	# Get the correct event type
 	var prev_event: InputEventWithModifiers = Utils.array_find_type(action_list, "InputEventKey")
+	var new_event: InputEventWithModifiers
+	
 	if prev_event == null:
 		prev_event = Utils.array_find_type(action_list, "InputEventMouseButton")
-	var new_event: InputEventWithModifiers
+	
+	# Create the correct event type based on the value
 	if value["value"] > 24:
 		new_event = InputEventKey.new()
 		new_event.scancode = value["value"]

--- a/addons/GGS/src/components/keybind/ggs_keybind_kb.gd
+++ b/addons/GGS/src/components/keybind/ggs_keybind_kb.gd
@@ -5,6 +5,9 @@ var script_instance: Object
 
 # Resources
 onready var ConfirmPopup: PackedScene = preload("KeybindConfirm.tscn")
+const mouse_btn_names := {"1": "Left Mouse Button", "2": "Right Mouse Button", "3": "Middle Mouse Button",
+							"4": "Mouse Wheel Up", "5": "Mouse Wheel Down", "6": "Mouse Wheel Left",
+							"7": "Mouse Wheel Right", "8": "Mouse Extra Button 1", "9": "Mouse Extra Button 2"}
 
 
 func _ready() -> void:
@@ -28,8 +31,13 @@ func _ready() -> void:
 
 func reset_to_default() -> void:
 	var default: Dictionary = ggsManager.settings_data[str(setting_index)]["default"]
-	var event: InputEventKey = InputEventKey.new()
-	event.scancode = default["value"]
+	var event: InputEventWithModifiers
+	if default["value"] > 24:
+		event = InputEventKey.new()
+		event.scancode = default["value"]
+	else:
+		event = InputEventMouseButton.new()
+		event.button_index = default["value"]
 	_on_ConfirmPopup_confirmed(event)
 
 
@@ -43,17 +51,30 @@ func _on_pressed() -> void:
 	release_focus()
 
 
-func _on_ConfirmPopup_confirmed(event: InputEventKey) -> void:
+func _on_ConfirmPopup_confirmed(event: InputEventWithModifiers) -> void:
 	# Update save value
 	var current: Dictionary = ggsManager.settings_data[str(setting_index)]["current"]
-	current["value"] = event.scancode
+	if event is InputEventKey:
+		current["value"] = event.scancode
+	else:
+		current["value"] = event.button_index
 	ggsManager.save_settings_data()
 	
 	# Update display value
 	if icon != null:
-		icon.current_frame = event.scancode
+		if event is InputEventKey:
+			icon.current_frame = event.scancode
+		else:
+			icon.current_frame = event.button_index
 	else:
-		text = OS.get_scancode_string(event.scancode)
+		if event is InputEventKey:
+			text = OS.get_scancode_string(event.scancode)
+		else:
+			text = mouse_btn_names[str(event.button_index)]
 	
 	# Execute the logic script
 	script_instance.main(current)
+
+
+func _on_Button_button_down():
+	pass # Replace with function body.

--- a/addons/GGS/src/components/keybind/ggs_keybind_kb.gd
+++ b/addons/GGS/src/components/keybind/ggs_keybind_kb.gd
@@ -19,7 +19,10 @@ func _ready() -> void:
 	if icon != null:
 		icon.current_frame = value
 	else:
-		text = OS.get_scancode_string(value)
+		if value > 24:
+			text = OS.get_scancode_string(value)
+		else:
+			text = mouse_btn_names[str(value)]
 	
 	# Load Script
 	var script: Script = load(ggsManager.settings_data[str(setting_index)]["logic"])

--- a/addons/GGS/src/components/keybind/ggs_keybind_kb.gd
+++ b/addons/GGS/src/components/keybind/ggs_keybind_kb.gd
@@ -5,9 +5,6 @@ var script_instance: Object
 
 # Resources
 onready var ConfirmPopup: PackedScene = preload("KeybindConfirm.tscn")
-const mouse_btn_names := {"1": "Left Mouse Button", "2": "Right Mouse Button", "3": "Middle Mouse Button",
-							"4": "Mouse Wheel Up", "5": "Mouse Wheel Down", "6": "Mouse Wheel Left",
-							"7": "Mouse Wheel Right", "8": "Mouse Extra Button 1", "9": "Mouse Extra Button 2"}
 
 
 func _ready() -> void:
@@ -22,7 +19,7 @@ func _ready() -> void:
 		if value > 24:
 			text = OS.get_scancode_string(value)
 		else:
-			text = mouse_btn_names[str(value)]
+			text = _get_mouse_button_string(value)
 	
 	# Load Script
 	var script: Script = load(ggsManager.settings_data[str(setting_index)]["logic"])
@@ -73,11 +70,22 @@ func _on_ConfirmPopup_confirmed(event: InputEventWithModifiers) -> void:
 		if event is InputEventKey:
 			text = OS.get_scancode_string(event.scancode)
 		else:
-			text = mouse_btn_names[str(event.button_index)]
+			text = _get_mouse_button_string(event.button_index)
 	
 	# Execute the logic script
 	script_instance.main(current)
 
 
-func _on_Button_button_down():
-	pass # Replace with function body.
+func _get_mouse_button_string(button_index: int) -> String:
+	var strings: Dictionary = {
+		"1": "LMB",
+		"2": "RMB",
+		"3": "MMB",
+		"4": "MW Up",
+		"5": "Mw Down",
+		"6": "MW Left",
+		"7": "MW Right",
+		"8": "Mouse Extra 1",
+		"9": "Mouse Extra 2",
+	}
+	return strings[str(button_index)]

--- a/addons/GGS/src/components/keybind/keybind_confirm.gd
+++ b/addons/GGS/src/components/keybind/keybind_confirm.gd
@@ -20,7 +20,7 @@ func _input(event: InputEvent) -> void:
 	# Only accept the correct type
 	match type:
 		Type.Keyboard:
-			if not event is InputEventKey:
+			if not (event is InputEventKey or event is InputEventMouseButton):
 				return
 		Type.Gamepad:
 			if not event is InputEventJoypadButton:


### PR DESCRIPTION
In games, especially FPS games, you'll want mouse button support. However, the stock version from the Godot Assets page doesn't have it, so this pull request will add it. It basically replaces InputEventKey with InputEventWithModifiers and since there aren't any keys before scancode 32, check if the value is less than 24 and if it is, interpret it as a mouse button