### PR TITLE
Check tree_already_paused when closing keybindConfirm to timeout

### DIFF
--- a/addons/GGS/src/components/keybind/keybind_confirm.gd
+++ b/addons/GGS/src/components/keybind/keybind_confirm.gd
@@ -61,6 +61,7 @@ func _get_non_ui_actions(actions: Array) -> Array:
 
 # Auto close the popup after a while to prevent the player from being stuck on the popup
 func _on_Timer_timeout() -> void:
-	get_tree().paused = false
+	if not tree_already_paused:
+		get_tree().paused = false
 	source.grab_focus()
 	queue_free()


### PR DESCRIPTION
This is a small error I caught while debugging the menu. My main-menu pauses the tree, so I rely on the tree_already_paused check for when it closes, but the auto-close method doesn't use it (unlike the keybind-selected closing method, which uses on line 60 it and works perfectly).

This PR checks tree_already_paused so the game won't accidentally be unpaused when the keybindConfirm window times out.